### PR TITLE
fix(Page): add screen dpi property to page.pdf method

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1514,6 +1514,7 @@ Page is guaranteed to have a main frame which persists during navigations.
     - `bottom` <[string]|[number]> Bottom margin, accepts values labeled with units.
     - `left` <[string]|[number]> Left margin, accepts values labeled with units.
   - `preferCSSPageSize` <[boolean]> Give any CSS `@page` size declared in the page priority over what is declared in `width` and `height` or `format` options. Defaults to `false`, which will scale the content to fit the paper size.
+  - `dpi` <[number]> Screen dpi. Defaults to 96.
 - returns: <[Promise]<[Buffer]>> Promise which resolves with PDF buffer.
 
 > **NOTE** Generating a pdf is currently only supported in Chrome headless.

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -936,7 +936,8 @@ class Page extends EventEmitter {
       pageRanges = '',
       preferCSSPageSize = false,
       margin = {},
-      path = null
+      path = null,
+      dpi = 96
     } = options;
 
     let paperWidth = 8.5;
@@ -947,14 +948,14 @@ class Page extends EventEmitter {
       paperWidth = format.width;
       paperHeight = format.height;
     } else {
-      paperWidth = convertPrintParameterToInches(options.width) || paperWidth;
-      paperHeight = convertPrintParameterToInches(options.height) || paperHeight;
+      paperWidth = convertPrintParameterToInches(options.width, dpi) || paperWidth;
+      paperHeight = convertPrintParameterToInches(options.height, dpi) || paperHeight;
     }
 
-    const marginTop = convertPrintParameterToInches(margin.top) || 0;
-    const marginLeft = convertPrintParameterToInches(margin.left) || 0;
-    const marginBottom = convertPrintParameterToInches(margin.bottom) || 0;
-    const marginRight = convertPrintParameterToInches(margin.right) || 0;
+    const marginTop = convertPrintParameterToInches(margin.top, dpi) || 0;
+    const marginLeft = convertPrintParameterToInches(margin.left, dpi) || 0;
+    const marginBottom = convertPrintParameterToInches(margin.bottom, dpi) || 0;
+    const marginRight = convertPrintParameterToInches(margin.right, dpi) || 0;
 
     const result = await this._client.send('Page.printToPDF', {
       landscape,
@@ -1114,6 +1115,7 @@ class Page extends EventEmitter {
  * @property {boolean=} preferCSSPageSize
  * @property {!{top?: string|number, bottom?: string|number, left?: string|number, right?: string|number}=} margin
  * @property {string=} path
+ * @property {number=} dpi
  */
 
 /**
@@ -1185,9 +1187,10 @@ const unitToPixels = {
 
 /**
  * @param {(string|number|undefined)} parameter
+ * @param {(number)} dpi
  * @return {(number|undefined)}
  */
-function convertPrintParameterToInches(parameter) {
+function convertPrintParameterToInches(parameter, dpi) {
   if (typeof parameter === 'undefined')
     return undefined;
   let pixels;
@@ -1212,7 +1215,7 @@ function convertPrintParameterToInches(parameter) {
   } else {
     throw new Error('page.pdf() Cannot handle parameter type: ' + (typeof parameter));
   }
-  return pixels / 96;
+  return pixels / dpi;
 }
 
 /**


### PR DESCRIPTION
This patch adds the dpi property to the page.pdf method to fix pdf output resolution

Fixes #3098, Fixes #666